### PR TITLE
added #! to use python2 in python scripts

### DIFF
--- a/py/crabllvm.py
+++ b/py/crabllvm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import os

--- a/py/setup.py
+++ b/py/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 from distutils.core import setup
 from os.path import join
 

--- a/py/stats.py
+++ b/py/stats.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 # simple statistics module
 
 import resource


### PR DESCRIPTION
The crab-llvm scripts had problems running on platforms where Python3 was the default python distribution instead of Python2.
This was easily fixed by adjusting the she-bang in all executable python scripts with `/usr/bin/env python2`.