### PR TITLE
feat(cfg): convert unsigned comparison to signed comparisons

### DIFF
--- a/include/clam/CfgBuilderParams.hh
+++ b/include/clam/CfgBuilderParams.hh
@@ -27,6 +27,9 @@ struct CrabBuilderParams {
   // Translate bignums (> 64), otherwise operations with big numbers
   // are havoced.
   bool enable_bignums;
+  // Lower unsigned comparison operators into signed one
+  // The translation is made under crab IR
+  bool lower_unsigned_icmp;
   // Avoid adding boolean crabIR statements in some cases (e.g.,
   // bool_assume/bool_assert) because Crab is, in general, not very
   // good at boolean reasoning.
@@ -51,21 +54,14 @@ struct CrabBuilderParams {
   bool dot_cfg;
 
   CrabBuilderParams()
-      : precision_level(CrabBuilderPrecision::NUM),
-	simplify(false),
-        interprocedural(true),
-	lower_singleton_aliases(false),
-        include_useless_havoc(true),
-	avoid_boolean(true),
-	enable_bignums(false),
-        add_pointer_assumptions(true),
-	add_null_checks(false),
-	add_uaf_checks(false),
-	add_bounds_checks(false),
-	check_only_typed_regions(false),
-	check_only_noncyclic_regions(false),
-	print_cfg(false),
-	dot_cfg(false) {}
+      : precision_level(CrabBuilderPrecision::NUM), simplify(false),
+        interprocedural(true), lower_singleton_aliases(false),
+        include_useless_havoc(true), avoid_boolean(true),
+        lower_unsigned_icmp(false), enable_bignums(false),
+        add_pointer_assumptions(true), add_null_checks(false),
+        add_uaf_checks(false), add_bounds_checks(false),
+        check_only_typed_regions(false), check_only_noncyclic_regions(false),
+        print_cfg(false), dot_cfg(false) {}
 
   bool trackMemory() const {
     return precision_level == CrabBuilderPrecision::MEM;
@@ -77,6 +73,14 @@ struct CrabBuilderParams {
 
   bool addPointerAssumptions() const {
     return trackMemory() && add_pointer_assumptions;
+  }
+
+  /* Set lower unsigned cmp into signed for Crab programs */
+  void lowerUnsignedICmpIntoSigned() {
+    if (!lower_unsigned_icmp) {
+      lower_unsigned_icmp = true;
+      avoid_boolean = false;
+    }
   }
 
   /* Set the level of abstraction for Crab programs */

--- a/lib/Clam/CfgBuilder.cc
+++ b/lib/Clam/CfgBuilder.cc
@@ -147,6 +147,101 @@ static void havoc(var_t v, std::string comment, basic_block_t &bb,
   }
 }
 
+static void
+addUnsignedCmpTranslationIntoSign(var_t &res, lin_exp_t &op0, lin_exp_t &op1,
+                                  crabLitFactory &lfac, basic_block_t &bb,
+                                  const bool isNegated, const bool isCmpULE) {
+  // translating unsigned comparisons by using select operators
+  // x cmp y, where cmp will be either <= or <
+  // will be translated into:
+  // if x >= 0
+  //     if y >= 0 then x cmp y
+  //     else // x >= 0 y < 0
+  //        false
+  // else
+  //     if y >= 0 then // x < 0 y >= 0
+  //        true
+  //     else x cmp y
+  // reverse cmp, true and false if isNegated is set
+  lin_cst_t cmp;
+  if (isCmpULE) {
+    if (!isNegated)
+      cmp = lin_cst_t(op0 <= op1);
+    else
+      cmp = lin_cst_t(op0 >= op1 + number_t(1));
+  } else {
+    if (!isNegated)
+      cmp = lin_cst_t(op0 <= op1 - number_t(1));
+    else
+      cmp = lin_cst_t(op0 >= op1);
+  }
+  lin_cst_t cst_op0 = lin_cst_t(op0 >= 0);
+  lin_cst_t cst_op1 = lin_cst_t(op1 >= 0);
+  if (cst_op0.is_tautology()) {   // if the first operand is >= 0
+    if (cst_op1.is_tautology()) { // if the second operand is >= 0
+      bb.bool_assign(res, cmp);
+    } else if (cst_op1.is_contradiction()) { // if the second operand is < 0
+      bb.bool_assign(res, !isNegated ? lin_cst_t::get_false()
+                                     : lin_cst_t::get_true());
+    } else { // don't know the value of the second operand
+      var_t select_cond_1 = lfac.mkBoolVar();
+      bb.bool_assign(select_cond_1, cst_op1);
+      var_t cmp_var = lfac.mkBoolVar();
+      bb.bool_assign(cmp_var, cmp);
+      var_t v_false = lfac.mkBoolVar();
+      bb.bool_assign(v_false, !isNegated ? lin_cst_t::get_false()
+                                         : lin_cst_t::get_true());
+      bb.bool_select(res, select_cond_1, cmp_var, v_false);
+    }
+  } else if (cst_op0.is_contradiction()) { // if the first operand is < 0
+    if (cst_op1.is_tautology()) {          // if the second operand is >= 0
+      bb.bool_assign(res, !isNegated ? lin_cst_t::get_true()
+                                     : lin_cst_t::get_false());
+    } else if (cst_op1.is_contradiction()) { // if the second operand is < 0
+      bb.bool_assign(res, cmp);
+    } else { // don't know the value of the second operand
+      var_t select_cond_1 = lfac.mkBoolVar();
+      bb.bool_assign(select_cond_1, cst_op1);
+      var_t v_true = lfac.mkBoolVar();
+      bb.bool_assign(v_true, !isNegated ? lin_cst_t::get_true()
+                                        : lin_cst_t::get_false());
+      var_t cmp_var = lfac.mkBoolVar();
+      bb.bool_assign(cmp_var, cmp);
+      bb.bool_select(res, select_cond_1, v_true, cmp_var);
+    }
+  } else { // don't know the value of the first operand
+    var_t select_cond_2 = lfac.mkBoolVar();
+    var_t op0_ge_0 = lfac.mkBoolVar();
+    var_t op0_lt_0 = lfac.mkBoolVar();
+    bb.bool_assign(select_cond_2, cst_op0);
+    if (cst_op1.is_tautology()) { // if the second operand is >= 0
+      bb.bool_assign(op0_ge_0, cmp);
+      bb.bool_assign(op0_lt_0, !isNegated ? lin_cst_t::get_true()
+                                          : lin_cst_t::get_false());
+    } else if (cst_op1.is_contradiction()) { // if the second operand is < 0
+      bb.bool_assign(op0_ge_0, !isNegated ? lin_cst_t::get_false()
+                                          : lin_cst_t::get_true());
+      bb.bool_assign(op0_lt_0, cmp);
+    } else { // don't know the value of those operands, general cases
+      var_t select_cond_1 = lfac.mkBoolVar();
+      bb.bool_assign(select_cond_1, cst_op1);
+      var_t cmp_var_true = lfac.mkBoolVar();
+      bb.bool_assign(cmp_var_true, cmp);
+      var_t v_false = lfac.mkBoolVar();
+      bb.bool_assign(v_false, !isNegated ? lin_cst_t::get_false()
+                                         : lin_cst_t::get_true());
+      bb.bool_select(op0_ge_0, select_cond_1, cmp_var_true, v_false);
+      var_t cmp_var_false = lfac.mkBoolVar();
+      bb.bool_assign(cmp_var_false, cmp);
+      var_t v_true = lfac.mkBoolVar();
+      bb.bool_assign(v_true, !isNegated ? lin_cst_t::get_true()
+                                        : lin_cst_t::get_false());
+      bb.bool_select(op0_lt_0, select_cond_1, v_true, cmp_var_false);
+    }
+    bb.bool_select(res, select_cond_2, op0_ge_0, op0_lt_0);
+  }
+}
+
 // %x = icmp geq %y, 10  ---> bool_assign(%x, y >= 0)
 static void cmpInstToCrabBool(CmpInst &I, crabLitFactory &lfac,
                               basic_block_t &bb) {
@@ -193,7 +288,6 @@ static void cmpInstToCrabBool(CmpInst &I, crabLitFactory &lfac,
     bb.bool_assign(lhs, cst);
     break;
   }
-  case CmpInst::ICMP_ULT:
   case CmpInst::ICMP_SLT: {
     lin_cst_t cst(op0 <= op1 - number_t(1));
     if (I.getPredicate() == CmpInst::ICMP_ULT) {
@@ -202,13 +296,18 @@ static void cmpInstToCrabBool(CmpInst &I, crabLitFactory &lfac,
     bb.bool_assign(lhs, cst);
     break;
   }
-  case CmpInst::ICMP_ULE:
   case CmpInst::ICMP_SLE: {
     lin_cst_t cst(op0 <= op1);
     if (I.getPredicate() == CmpInst::ICMP_ULE) {
       cst.set_unsigned();
     }
     bb.bool_assign(lhs, cst);
+    break;
+  }
+  case CmpInst::ICMP_ULT:
+  case CmpInst::ICMP_ULE: {
+    addUnsignedCmpTranslationIntoSign(lhs, op0, op1, lfac, bb, false,
+                                      I.getPredicate() == CmpInst::ICMP_ULE);
     break;
   }
   default:
@@ -315,9 +414,10 @@ static Optional<ref_cst_t> cmpInstToCrabRef(CmpInst &I, crabLitFactory &lfac,
   return llvm::None;
 }
 
-/* If possible, return a Crab linear constraint from CmpInst */
-static Optional<lin_cst_t> cmpInstToCrabInt(CmpInst &I, crabLitFactory &lfac,
-                                            const bool isNegated = false) {
+/* signed only: If possible, return a Crab linear constraint from CmpInst */
+static Optional<lin_cst_t>
+signedCmpInstToCrabInt(CmpInst &I, crabLitFactory &lfac,
+                       const bool isNegated = false) {
   normalizeCmpInst(I);
 
   const Value &v0 = *I.getOperand(0);
@@ -375,6 +475,43 @@ static Optional<lin_cst_t> cmpInstToCrabInt(CmpInst &I, crabLitFactory &lfac,
   }
   default:;
     ;
+  }
+  return llvm::None;
+}
+
+/* unsigned only: If possible, return value assigned Crab variable from CmpInst
+ */
+static Optional<var_t> unsignedCmpInstToCrabInt(CmpInst &I,
+                                                crabLitFactory &lfac,
+                                                basic_block_t &bb,
+                                                const bool isNegated = false) {
+  normalizeCmpInst(I);
+
+  const Value &v0 = *I.getOperand(0);
+  const Value &v1 = *I.getOperand(1);
+
+  crab_lit_ref_t ref0 = lfac.getLit(v0);
+  if (!ref0 || !(ref0->isInt()))
+    return llvm::None;
+
+  crab_lit_ref_t ref1 = lfac.getLit(v1);
+  if (!ref1 || !(ref1->isInt()))
+    return llvm::None;
+
+  lin_exp_t op0 = lfac.getExp(ref0);
+  lin_exp_t op1 = lfac.getExp(ref1);
+
+  switch (I.getPredicate()) {
+  case CmpInst::ICMP_ULE:
+  case CmpInst::ICMP_ULT: {
+    var_t res = lfac.mkBoolVar();
+    addUnsignedCmpTranslationIntoSign(res, op0, op1, lfac, bb, isNegated,
+                                      I.getPredicate() == CmpInst::ICMP_ULE);
+    return res;
+    break;
+  }
+  default:
+    CLAM_ERROR("signed comparisons should call signed subroutine");
   }
   return llvm::None;
 }
@@ -1458,6 +1595,26 @@ void CrabIntraBlockBuilder::doVerifierCall(CallInst &I) {
       }
     }
   } else {
+    if (CmpInst *Cond = dyn_cast<CmpInst>(cond)) {
+      // Handle translation of unsigned cmp into signed
+      if (m_params.lower_unsigned_icmp &&
+          Cond->isUnsigned()) { // handle unsigned int
+        auto var_opt = unsignedCmpInstToCrabInt(*Cond, m_lfac, m_bb,
+                                                isNotAssumeFn(*callee));
+        if (var_opt.hasValue()) {
+          if (isAssertFn(*callee)) {
+            m_bb.bool_assert(var_opt.getValue(),
+                             getDebugLoc(&I, m_assertion_id++));
+          } else {
+            m_bb.bool_assume(var_opt.getValue());
+          }
+        } else {
+          // Unreachable
+          CLAM_WARNING("Could not translate unsigned comparisons: " << I);
+        }
+      }
+    }
+
     if (CmpInst *Cond = m_pending_cmp_insts[&I]) {      
       /*
        * Avoid boolean CrabIR statements: use numerical ones instead
@@ -1475,8 +1632,8 @@ void CrabIntraBlockBuilder::doVerifierCall(CallInst &I) {
        * If m_params.avoid_boolean = true then 
        *    assert(x rel_op y);
        */
-      
-      auto cst_opt = cmpInstToCrabInt(*Cond, m_lfac, isNotAssumeFn(*callee));
+      auto cst_opt =
+          signedCmpInstToCrabInt(*Cond, m_lfac, isNotAssumeFn(*callee));
       if (cst_opt.hasValue()) {
         if (isAssertFn(*callee)) {
           m_bb.assertion(cst_opt.getValue(), getDebugLoc(&I, m_assertion_id++));
@@ -1971,9 +2128,16 @@ void CrabIntraBlockBuilder::visitSelectInst(SelectInst &I) {
 
     // -- general case: we don't know whether the condition is true or not
     if (CmpInst *CI = dyn_cast<CmpInst>(&condV)) {
-      if (auto cst_opt = cmpInstToCrabInt(*CI, m_lfac)) {
-        m_bb.select(lhs->getVar(), *cst_opt, e1, e2);
-        return;
+      if (m_params.lower_unsigned_icmp && CI->isUnsigned()) {
+        if (auto var_opt = unsignedCmpInstToCrabInt(*CI, m_lfac, m_bb)) {
+          m_bb.select(lhs->getVar(), *var_opt, e1, e2);
+          return;
+        }
+      } else {
+        if (auto cst_opt = signedCmpInstToCrabInt(*CI, m_lfac)) {
+          m_bb.select(lhs->getVar(), *cst_opt, e1, e2);
+          return;
+        }
       }
     }
 
@@ -3650,9 +3814,17 @@ basic_block_t *CfgBuilderImpl::execEdge(const BasicBlock &src,
             lower_cond_as_bool = true;
           } else if (isInteger(*(CI->getOperand(0))) &&
                      isInteger(*(CI->getOperand(1)))) {
-            auto cst_opt = cmpInstToCrabInt(*CI, m_lfac, isNegated);
-            if (cst_opt.hasValue()) {
-              bb.assume(cst_opt.getValue());
+            if (m_params.lower_unsigned_icmp && CI->isUnsigned()) {
+              auto var_opt =
+                  unsignedCmpInstToCrabInt(*CI, m_lfac, bb, isNegated);
+              if (var_opt.hasValue()) {
+                bb.bool_assume(var_opt.getValue());
+              }
+            } else {
+              auto cst_opt = signedCmpInstToCrabInt(*CI, m_lfac, isNegated);
+              if (cst_opt.hasValue()) {
+                bb.assume(cst_opt.getValue());
+              }
             }
           } else if (isReference(*(CI->getOperand(0)), m_params) &&
                      isReference(*(CI->getOperand(1)), m_params)) {

--- a/lib/Clam/Clam.cc
+++ b/lib/Clam/Clam.cc
@@ -1195,7 +1195,10 @@ bool ClamPass::runOnModule(Module &M) {
   builder_params.check_only_noncyclic_regions = CrabCheckOnlyNonCyclic;
   builder_params.print_cfg = CrabPrintCFG;
   builder_params.dot_cfg = CrabDotCFG;
-  
+
+  if (CrabLowerUnsignedICmp)
+    builder_params.lowerUnsignedICmpIntoSigned();
+
   auto &tli = getAnalysis<TargetLibraryInfoWrapperPass>();
 
   /// Create the CFG builder manager

--- a/lib/Clam/ClamOptions.def
+++ b/lib/Clam/ClamOptions.def
@@ -14,6 +14,7 @@ bool CrabPrintCFG;
 bool CrabDotCFG;
 bool CrabEnableUniqueScalars;
 bool CrabIncludeHavoc;
+bool CrabLowerUnsignedICmp;
 bool CrabEnableBignums;
 bool CrabAddPtrAssumptions;
 bool CrabNullChecks;
@@ -141,6 +142,12 @@ llvm::cl::opt<bool, true>
 XCrabBoundsChecks("crab-bounds-check",
      llvm::cl::desc("Insert checks for array bounds errors in CrabIR"),
      llvm::cl::location(clam::CrabBoundsChecks),
+     llvm::cl::init(false));
+
+llvm::cl::opt<bool, true>
+XCrabLowerUnsignedICmp("crab-lower-unsigned-icmp",
+     llvm::cl::desc("Insert translation from unsigned icmp into signed in CrabIR"),
+     llvm::cl::location(clam::CrabLowerUnsignedICmp),
      llvm::cl::init(false));
 
 /*** Crab Analysis Options ***/

--- a/py/clam.py
+++ b/py/clam.py
@@ -365,6 +365,9 @@ def parseArgs(argv):
     p.add_argument('--crab-live',
                     help='Delete dead symbols: may lose precision with relational domains.',
                     dest='crab_live', default=False, action='store_true')
+    add_bool_argument(p, 'crab-lower-unsigned-icmp', default=False,
+                    help='Lower ULT and ULE instructions in CrabIR',
+                    dest='crab_lower_unsigned_icmp')
     p.add_argument('--crab-opt',
                     help='Optimize LLVM bitcode using invariants',
                     choices=['none',
@@ -819,6 +822,9 @@ def clam(in_name, out_name, args, extra_opts, cpu = -1, mem = -1):
         clam_args.append('--clam-lower-constant-expr=false')
     if args.disable_lower_switch:
         clam_args.append('--clam-lower-switch=false')
+
+    if args.crab_lower_unsigned_icmp:
+        clam_args.append('--crab-lower-unsigned-icmp')
 
     clam_args.append('--crab-dom={0}'.format(args.crab_dom))
     clam_args.append('--crab-widening-delay={0}'.format(args.widening_delay))


### PR DESCRIPTION
convert a general pattern for unsigned comparison `cmp` such as `x <u y` or `x <= u y` as the following 
```c
if (x >= 0) {
    if y >= 0 then x cmp y
    else // x >= 0 y < 0
        false
}
else {
    if y >= 0 then // x < 0 y >= 0
        true
    else x cmp y
}
```
The implementation is using multiple `select` operations during the construction of a cfg graph. The simplification process is introduced.
