### PR TITLE
feat(lib): add havoc insertion by cfg emitter

### DIFF
--- a/lib/Clam/CfgBuilder.cc
+++ b/lib/Clam/CfgBuilder.cc
@@ -3123,7 +3123,10 @@ void CrabIntraBlockBuilder::visitCallInst(CallInst &I) {
             I, m_params) /* && ShouldCallSiteReturn(I, m_params)*/) {
       crab_lit_ref_t lhs = m_lfac.getLit(I);
       assert(lhs && lhs->isVar());
-      havoc(lhs->getVar(), valueToStr(I), m_bb, m_params.include_useless_havoc);
+      std::vector<var_t> inputs_ref{lhs->getVar()};
+      insertCrabIRWithEmitter::havoc_with_ref_input(
+          I, m_propertyEmitters, m_bb, inputs_ref, std::vector<var_t>(),
+          callee->getName());
       if (isReference(I, m_params)) {
 	Region rgn_lhs = getRegion(m_mem, m_func_regions, m_params, I, I);
 	if (m_params.addPointerAssumptions()) {

--- a/lib/Clam/CfgBuilderEmitters.cc
+++ b/lib/Clam/CfgBuilderEmitters.cc
@@ -117,4 +117,23 @@ const statement_t *insertCrabIRWithEmitter::select_ref(
   return res;
 }
 
+const statement_t *insertCrabIRWithEmitter::havoc_with_ref_input(
+    llvm::CallBase &I, CrabIREmitterVec &propertyEmitters, basic_block_t &bb,
+    std::vector<var_t> inputs_ref, std::vector<var_t> inputs_region,
+    std::string func_name) {
+  CrabCallSiteOps s(inputs_ref, inputs_region, std::vector<var_t>(),
+                    std::vector<var_t>(), func_name, bb);
+  for (unsigned i = 0, sz = propertyEmitters.size(); i < sz; ++i) {
+    propertyEmitters[i]->visitBeforeCallSite(I, s);
+  }
+  std::string strInst;
+  raw_string_ostream os(strInst);
+  os << I;
+  const statement_t *res = bb.havoc(inputs_ref[0], strInst);
+  for (unsigned i = 0, sz = propertyEmitters.size(); i < sz; ++i) {
+    propertyEmitters[i]->visitAfterCallSite(I, s);
+  }
+  return res;
+}
+
 } // end namespace clam

--- a/lib/Clam/CfgBuilderEmitters.hh
+++ b/lib/Clam/CfgBuilderEmitters.hh
@@ -54,6 +54,11 @@ public:
                                        var_t lhs_region, var_t cond,
                                        CrabSelectRefOps::opt_pair_var_t op1,
                                        CrabSelectRefOps::opt_pair_var_t op2);
+  // Insert havoc with ref inputs statement in bb
+  static const statement_t *
+  havoc_with_ref_input(llvm::CallBase &I, CrabIREmitterVec &propertyEmitters,
+                       basic_block_t &bb, std::vector<var_t> inputs_ref,
+                       std::vector<var_t> inputs_region, std::string func_name);
 };
 
 } // namespace clam

--- a/lib/Clam/Properties/NullCheck.cc
+++ b/lib/Clam/Properties/NullCheck.cc
@@ -182,6 +182,10 @@ void EmitNullDerefChecks::visitBeforeRefSelect(llvm::SelectInst &I,
                                                CrabSelectRefOps &s) {}
 void EmitNullDerefChecks::visitAfterRefSelect(llvm::SelectInst &I,
                                               CrabSelectRefOps &s) {}
+void EmitNullDerefChecks::visitBeforeCallSite(llvm::CallBase &I,
+                                              CrabCallSiteOps &s) {}
+void EmitNullDerefChecks::visitAfterCallSite(llvm::CallBase &I,
+                                             CrabCallSiteOps &s) {}
 /* End empty implementations */
 
 } // end namespace clam

--- a/lib/Clam/Properties/NullCheck.hh
+++ b/lib/Clam/Properties/NullCheck.hh
@@ -48,6 +48,10 @@ public:
                                     CrabSelectRefOps &s) override;
   virtual void visitAfterRefSelect(llvm::SelectInst &I,
                                    CrabSelectRefOps &s) override;
+  virtual void visitBeforeCallSite(llvm::CallBase &I,
+                                   CrabCallSiteOps &s) override;
+  virtual void visitAfterCallSite(llvm::CallBase &I,
+                                  CrabCallSiteOps &s) override;
 };
 
 } // end namespace clam

--- a/lib/Clam/Properties/UafCheck.cc
+++ b/lib/Clam/Properties/UafCheck.cc
@@ -177,6 +177,9 @@ void EmitUafChecks::visitBeforeRefSelect(llvm::SelectInst &I,
                                          CrabSelectRefOps &s) {}
 void EmitUafChecks::visitAfterRefSelect(llvm::SelectInst &I,
                                         CrabSelectRefOps &s) {}
+void EmitUafChecks::visitBeforeCallSite(llvm::CallBase &I, CrabCallSiteOps &s) {
+}
+void EmitUafChecks::visitAfterCallSite(llvm::CallBase &I, CrabCallSiteOps &s) {}
 /* End empty implementations */
 
 } // end namespace clam

--- a/lib/Clam/Properties/UafCheck.hh
+++ b/lib/Clam/Properties/UafCheck.hh
@@ -48,6 +48,10 @@ public:
                                     CrabSelectRefOps &s) override;
   virtual void visitAfterRefSelect(llvm::SelectInst &I,
                                    CrabSelectRefOps &s) override;
+  virtual void visitBeforeCallSite(llvm::CallBase &I,
+                                   CrabCallSiteOps &s) override;
+  virtual void visitAfterCallSite(llvm::CallBase &I,
+                                  CrabCallSiteOps &s) override;
 };
 
 } // end namespace clam


### PR DESCRIPTION
Add `visitBeforeCallSite(CallBase &CB)` and `visitAfterCallSite(CallBase &CB)` APIs for memory checks.