### PR TITLE
fix(cfg): convert signed nums to unsigned if meets unsigned operators

### DIFF
--- a/docker/clam.Dockerfile
+++ b/docker/clam.Dockerfile
@@ -48,6 +48,7 @@ RUN cmake --build . --target test-ssh-simplified
 RUN cmake --build . --target test-ntdrivers-simplified
 RUN cmake --build . --target test-array-adapt
 RUN cmake --build . --target test-mem
+RUN cmake --build . --target test-lower-unsigned
 
 WORKDIR /clam
 

--- a/lib/Clam/CfgBuilderUtils.cc
+++ b/lib/Clam/CfgBuilderUtils.cc
@@ -50,7 +50,7 @@ bool isReference(const Value &v, const CrabBuilderParams &params) {
 }
 
 z_number toZNumber(const APInt &v, const CrabBuilderParams &params,
-                   bool &is_bignum) {
+                   bool &is_bignum, bool signed_to_unsigned) {
   is_bignum = false;
   if (!params.enable_bignums) {
     is_bignum = isSignedBigNum(v);
@@ -64,13 +64,13 @@ z_number toZNumber(const APInt &v, const CrabBuilderParams &params,
   // Based on:
   // https://llvm.org/svn/llvm-project/polly/trunk/lib/Support/GICHelper.cpp
   APInt abs;
-  abs = v.isNegative() ? v.abs() : v;
+  abs = v.isNegative() && !signed_to_unsigned ? v.abs() : v;
   const uint64_t *rawdata = abs.getRawData();
   unsigned numWords = abs.getNumWords();
 
   ikos::z_number res;
   mpz_import(res.get_mpz_t(), numWords, -1, sizeof(uint64_t), 0, 0, rawdata);
-  return v.isNegative() ? -res : res;
+  return v.isNegative() && !signed_to_unsigned ? -res : res;
 #endif
 }
 

--- a/lib/Clam/CfgBuilderUtils.hh
+++ b/lib/Clam/CfgBuilderUtils.hh
@@ -36,7 +36,7 @@ bool isReference(const llvm::Value &v, const CrabBuilderParams &params);
 
 // Converts v to z_number. Assumes that v is signed
 ikos::z_number toZNumber(const llvm::APInt &v, const CrabBuilderParams &params,
-                         bool &is_bignum);
+                         bool &is_bignum, bool signed_to_unsigned = false);
 
 // The return value should be z_number and not number_t
 ikos::z_number getIntConstant(const llvm::ConstantInt *CI,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,13 @@ add_lit_testsuite(test-readme "Run README.md tests"
   test_dir=${CMAKE_CURRENT_BINARY_DIR}/demo
   DEPENDS clam)
 
+add_lit_testsuite(test-lower-unsigned "Run tests for loswer-unsigned"
+  -v
+  ${CMAKE_CURRENT_SOURCE_DIR}/lower-unsigned  ## where .cfg file is located
+  PARAMS
+  test_dir=${CMAKE_CURRENT_BINARY_DIR}/lower-unsigned
+  DEPENDS clam)
+
 if (CRAB_USE_LDD)
   add_lit_testsuite(test-ssh "Run SVCOMP ssh benchmarks"
     -v 

--- a/tests/lower-unsigned/test_lower_unsigned_1.c
+++ b/tests/lower-unsigned/test_lower_unsigned_1.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <limits.h>
+
+// RUN: %clam -O0 --crab-lower-unsigned-icmp --crab-dom=pk --crab-check=assert "%s" 2>&1 | OutputCheck %s
+// CHECK: ^2  Number of total safe checks$
+// CHECK: ^1  Number of total warning checks$
+
+/* Externalize Helper Function */
+extern size_t size_t_nd(void);
+extern bool bool_nd(void);
+extern int int_nd(void);
+extern void __CRAB_assert(int);
+extern void __CRAB_assume(int);
+
+int main(void) {
+    size_t len = size_t_nd();
+    size_t cap = size_t_nd();
+    size_t max = 10;
+    // _1 = cap >= 0
+    // _2 = cap <= 10
+    // _3 = _1 & _2
+    __CRAB_assume(cap >= 0);
+    __CRAB_assume(cap <= max);
+    // __CRAB_assume(cap >= 0 && cap <= max);
+    /* INVARIANTS: ({_3 -> true}, {cap <= 10; cap >= 0}) */
+    // _4 = len >= 0
+    // _5 = len <= cap
+    // _6 = _4 & _5
+    __CRAB_assume(len >= 0);
+    __CRAB_assume(len <= cap);
+    /* INVARIANTS: 
+        ({_3 -> true; _6 -> true}, 
+        {cap <= 10; cap >= 0; len >= 0; len <= cap})
+    */
+
+    if (cap == 0) {
+        /* INVARIANTS: ({_3 -> true; _6 -> true}, {cap = 0; len = 0;}) */
+        __CRAB_assert(len == 0);
+    }
+    else {
+        /* INVARIANTS: ({_3 -> true; _6 -> true}, {cap > 0; len >= 0; len <= cap}) */
+        __CRAB_assert(len <= cap);
+    }
+    __CRAB_assert(cap >= 0 && cap <= max);
+    return 0;
+}

--- a/tests/lower-unsigned/test_lower_unsigned_2.c
+++ b/tests/lower-unsigned/test_lower_unsigned_2.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <limits.h>
+
+// RUN: %clam -O0 --inline --crab-lower-unsigned-icmp --crab-dom=pk --crab-check=assert "%s" 2>&1 | OutputCheck %s
+// CHECK: ^2  Number of total safe checks$
+// CHECK: ^0  Number of total warning checks$
+
+/* Externalize Helper Function */
+extern uint8_t uint8_t_nd(void);
+extern int8_t int8_t_nd(void);
+extern bool bool_nd(void);
+extern void __CRAB_assert(int);
+extern void __CRAB_assume(int);
+
+uint8_t uint8_t_nd(void) {
+    int8_t res = int8_t_nd();
+    __CRAB_assume(res > 0);
+    return res;
+}
+
+uint8_t call_f(uint8_t max_len) {
+    uint8_t len = uint8_t_nd();
+    __CRAB_assume(len <= max_len);
+    return len;
+}
+
+int main(void) {
+    int8_t max_len = 0b10000000; // unsigned: 128, singed: -128
+    uint8_t res_f = call_f(max_len);
+    __CRAB_assert(res_f < 129);
+    __CRAB_assert(res_f > 0);
+    return 0;
+}


### PR DESCRIPTION
When unsigned operator `uop` contains a signed number in LLVM IR, we need to convert the signed number to an unsigned number in CrabIR before lowering the unsigned operation to signed. For instance:
```llvm
%3 = icmp ult i64 %1, -26, !dbg !1010
```
should appear in crab IR:
```
@V_15 = (-_0 <= 0);
@V_16 = (_0 <= 18446744073709551589);
@V_17 = true;
_2 = ite(@V_15,@V_16,@V_17);
```