### PR TITLE
fix(NameValues): duplicate arg name

### DIFF
--- a/lib/Clam/NameValues.cc
+++ b/lib/Clam/NameValues.cc
@@ -12,7 +12,7 @@
 using namespace llvm;
 
 cl::opt<bool> UseCrabNameValues(
-    "crab-name-values",
+    "use-crab-name-values",
     cl::desc("Use own crab way of naming values, otherwise LLVM instnamer"),
     cl::init(true));
 


### PR DESCRIPTION
The command-line option "crab-name-values" has the same name as the
pass, which causes issues when dynamic linking. Rename the former to
avoid this.

Can we also please port this patch to the other branches :) Thanks!