### PR TITLE
refactor(cfg-builder): split assume of conjunction into conjunction assumes

### DIFF
--- a/lib/Clam/CfgBuilderUtils.cc
+++ b/lib/Clam/CfgBuilderUtils.cc
@@ -172,6 +172,10 @@ bool isIntArray(const Type &T) {
           !(T.getArrayElementType()->isIntegerTy(1)));
 }
 
+bool isLogicAnd(const BinaryOperator &I) {
+  return (I.getOpcode() == Instruction::And && I.getType()->isIntegerTy(1));
+}
+
 // bool isPointerArray(const Type &T) {
 //   return (T.isArrayTy() && T.getArrayElementType()->isPointerTy());
 // }

--- a/lib/Clam/CfgBuilderUtils.hh
+++ b/lib/Clam/CfgBuilderUtils.hh
@@ -16,6 +16,7 @@ class DataLayout;
 class CastInt;
 class CmpInst;
 class MDNode;
+class BinaryOperator;
 } // namespace llvm
 
 namespace clam {
@@ -77,6 +78,8 @@ bool isBoolToInt(const llvm::CastInt &I);
 bool isBoolArray(const llvm::Type &T);
 
 bool isIntArray(const llvm::Type &T);
+
+bool isLogicAnd(const llvm::BinaryOperator &I);
 
 bool isAssertFn(const llvm::Function &F);
 

--- a/tests/simple/test-bool-5.c
+++ b/tests/simple/test-bool-5.c
@@ -1,0 +1,45 @@
+// RUN: %clam --crab-dom=zones --crab-track=mem --inline --crab-heap-analysis=cs-sea-dsa --lower-unsigned-icmp --crab-lower-with-overflow-intrinsics=true --crab-check=assert "%s" 2>&1 | OutputCheck %s
+// CHECK: ^2  Number of total safe checks$
+// CHECK: ^0  Number of total error checks$
+// CHECK: ^0  Number of total warning checks$
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+extern uint8_t uint8_t_nd(void);
+extern bool bool_nd(void);
+extern int int_nd(void);
+extern void __CRAB_assert(int);
+extern void __CRAB_assume(int);
+
+extern void no_op(size_t, size_t);
+
+size_t size_t_nd(void) {
+    int res = int_nd();
+    __CRAB_assume(res >= 0);
+    return res;
+}
+
+int main() {
+  
+  bool a = bool_nd();
+  bool b = bool_nd();
+  bool c = bool_nd();
+
+  __CRAB_assume(a && b); // translate into single assume
+
+  bool d = a && c; // should not translate
+
+  if (d) {
+    __CRAB_assert(b);
+  } else {
+    __CRAB_assume(d);
+  }
+
+  __CRAB_assert(d);
+
+  return 0;
+}


### PR DESCRIPTION
Given LLVM Code:
```
    %b = and i1 %x, %y
    ....
    assume(%b)
```
we translate to:
```
    assume(%x);
    assume(%y);
    assume(%b);
```