### PR TITLE
Use llvm::DenseSet for seadsa_heap_abs_impl::NodeSet

### DIFF
--- a/lib/Clam/SeaDsaHeapAbstraction.cc
+++ b/lib/Clam/SeaDsaHeapAbstraction.cc
@@ -33,7 +33,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <set>
 #include <unordered_map>
 
 namespace clam {
@@ -225,7 +224,7 @@ void SeaDsaHeapAbstractionImpl::computeReadModNewNodes(
 
   HeapAbstraction::RegionVec reads, mods, news;
   std::vector<HeapAbstraction::RegionVec> equivClasses;
-  for (const Node *n : reach) {
+  for (const Node *n : seadsa_heap_abs_impl::orderedNodes(reach)) {
     bool isRetReach = retReach.count(n) > 0;
 
     if (!isRetReach && !n->isRead() && !n->isModified()) {
@@ -305,11 +304,11 @@ void SeaDsaHeapAbstractionImpl::computeEquivClasses(const llvm::Function &f) {
   // and also reachable from locals
   for (auto &kv : G.scalars()) {
     if (const Node *n = kv.second->getNode()) {
-      markReachableNodes(n, reach);
+      seadsa_heap_abs_impl::markReachableNodes(n, reach);
     }
   }
 
-  for (const Node *n : reach) {
+  for (const Node *n : seadsa_heap_abs_impl::orderedNodes(reach)) {
     bool isRetReach = retReach.count(n) > 0;
     if (!isRetReach && !n->isRead() && !n->isModified()) {
       continue;
@@ -392,7 +391,7 @@ void SeaDsaHeapAbstractionImpl::computeReadModNewNodesFromCallSite(
   Graph::computeCalleeCallerMapping(CS, calleeG, callerG, simMap);
 
   std::vector<std::pair<Region, bool>> reads, mods, news;
-  for (const Node *n : reach) {
+  for (const Node *n : seadsa_heap_abs_impl::orderedNodes(reach)) {
     bool isRetReach = retReach.count(n) > 0;
 
     if (!isRetReach && !n->isRead() && !n->isModified()) {

--- a/lib/Clam/SeaDsaHeapAbstractionUtils.cc
+++ b/lib/Clam/SeaDsaHeapAbstractionUtils.cc
@@ -24,11 +24,7 @@ bool NodeOrdering::operator()(const seadsa::Node *n1,
 }
 
 OrderedNodeVec orderedNodes(const NodeSet &set) {
-  OrderedNodeVec nodes;
-  nodes.reserve(set.size());
-  for (const seadsa::Node *n : set) {
-    nodes.push_back(n);
-  }
+  OrderedNodeVec nodes(set.begin(), set.end());
   std::sort(nodes.begin(), nodes.end(), NodeOrdering{});
   return nodes;
 }

--- a/lib/Clam/SeaDsaHeapAbstractionUtils.cc
+++ b/lib/Clam/SeaDsaHeapAbstractionUtils.cc
@@ -23,18 +23,26 @@ bool NodeOrdering::operator()(const seadsa::Node *n1,
   return n1->getId() < n2->getId();
 }
 
-void set_difference(NodeSet &s1, NodeSet &s2) {
-  NodeSet s3;
-  std::set_difference(s1.begin(), s1.end(), s2.begin(), s2.end(),
-                      std::inserter(s3, s3.end()));
-  std::swap(s3, s1);
+OrderedNodeVec orderedNodes(const NodeSet &set) {
+  OrderedNodeVec nodes;
+  nodes.reserve(set.size());
+  for (const seadsa::Node *n : set) {
+    nodes.push_back(n);
+  }
+  std::sort(nodes.begin(), nodes.end(), NodeOrdering{});
+  return nodes;
 }
 
-void set_union(NodeSet &s1, NodeSet &s2) {
-  NodeSet s3;
-  std::set_union(s1.begin(), s1.end(), s2.begin(), s2.end(),
-                 std::inserter(s3, s3.end()));
-  std::swap(s3, s1);
+void set_difference(NodeSet &s1, const NodeSet &s2) {
+  for (const seadsa::Node *n : s2) {
+    s1.erase(n);
+  }
+}
+
+void set_union(NodeSet &s1, const NodeSet &s2) {
+  for (const seadsa::Node *n : s2) {
+    s1.insert(n);
+  }
 }
 
 bool isInteger::operator()(const llvm::Type *t) {

--- a/lib/Clam/SeaDsaHeapAbstractionUtils.hh
+++ b/lib/Clam/SeaDsaHeapAbstractionUtils.hh
@@ -1,7 +1,8 @@
 #pragma once
 #include "clam/config.h"
 
-#include <set>
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace llvm {
 class Type;
@@ -20,11 +21,14 @@ struct NodeOrdering {
   bool operator()(const seadsa::Node *n1, const seadsa::Node *n2) const;
 };
 
-using NodeSet = std::set<const seadsa::Node *, NodeOrdering>;
+using NodeSet = llvm::DenseSet<const seadsa::Node *>;
+using OrderedNodeVec = llvm::SmallVector<const seadsa::Node *, 16>;
 
-void set_difference(NodeSet &s1, NodeSet &s2);
+OrderedNodeVec orderedNodes(const NodeSet &set);
 
-void set_union(NodeSet &s1, NodeSet &s2);
+void set_difference(NodeSet &s1, const NodeSet &s2);
+
+void set_union(NodeSet &s1, const NodeSet &s2);
 
 void markReachableNodes(const seadsa::Node *n, NodeSet &set);
 


### PR DESCRIPTION
## Summary

- Replace `seadsa_heap_abs_impl::NodeSet` backing storage from `std::set` to `llvm::DenseSet`.
- Add `orderedNodes` to preserve deterministic node traversal where read/mod/new and equivalence-class results are built.
- Update NodeSet union and difference helpers to use `DenseSet` insert and erase operations.

## Why

`std::set` is inefficient for this use case because the node collections are primarily membership sets, so the tree ordering overhead is unnecessary. `llvm::DenseSet` is a better fit for lookup, insertion, and deletion. Where iteration order affects observable output, nodes are sorted explicitly by SeaDsa node ID before traversal.