### PR TITLE
port(llvm15): build clam against LLVM 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.3...4.0)
 
 project(Clam)
-set (Clam_VERSION_MAJOR 14)
+set (Clam_VERSION_MAJOR 15)
 set (Clam_VERSION_MINOR 0)
 set (Clam_VERSION_PATCH 0)
 set (Clam_VERSION_TWEAK "rc0")
@@ -13,7 +13,7 @@ cmake_policy(SET CMP0074 NEW)
 cmake_policy(SET CMP0077 NEW)
 endif()
 
-## LLVM 14 requires c++14
+## LLVM 15 requires c++14
 set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 set(CMAKE_CXX_EXTENSIONS NO)
@@ -233,13 +233,16 @@ endif ()
 
 
 if (TopLevel)
-  find_package(LLVM 14 CONFIG)
+  # LLVM 15 (Ubuntu package) exposes zstd::libzstd_shared in its export set.
+  # Pull in zstd's imported targets first so find_package(LLVM) can resolve it.
+  find_package (zstd QUIET)
+  find_package(LLVM 15 CONFIG)
   if (NOT LLVM_FOUND)
     ExternalProject_Get_Property (llvm INSTALL_DIR)
     set (LLVM_ROOT ${INSTALL_DIR})
     set (LLVM_DIR ${LLVM_ROOT}/lib/cmake/llvm CACHE PATH
       "Forced location of LLVM cmake config" FORCE)
-    message (WARNING "No llvm found. Install LLVM 14.")
+    message (WARNING "No llvm found. Install LLVM 15.")
     return()
   else()
     message(STATUS "Clam: found LLVM ${LLVM_PACKAGE_VERSION}")

--- a/cmake/llvm-seahorn-git.cmake
+++ b/cmake/llvm-seahorn-git.cmake
@@ -2,5 +2,5 @@ set(SEAHORN_LLVM_SOURCE_DIR "${CMAKE_SOURCE_DIR}/llvm-seahorn" CACHE STRING "sea
 if (TopLevel)
   set(SEAHORN_LLVM_REPO "https://github.com/seahorn/llvm-seahorn" CACHE STRING "seahorn-llvm repo")
   add_custom_target(seahorn-llvm-git
-    ${GIT_EXECUTABLE} clone -b dev14 ${SEAHORN_LLVM_REPO} ${SEAHORN_LLVM_SOURCE_DIR})
+    ${GIT_EXECUTABLE} clone -b dev15 ${SEAHORN_LLVM_REPO} ${SEAHORN_LLVM_SOURCE_DIR})
 endif()

--- a/cmake/seadsa-git.cmake
+++ b/cmake/seadsa-git.cmake
@@ -2,5 +2,5 @@ set(SEADSA_SOURCE_DIR "${CMAKE_SOURCE_DIR}/sea-dsa" CACHE STRING "seadsa source 
 if (TopLevel)
   set(SEA_DSA_REPO "https://github.com/seahorn/sea-dsa" CACHE STRING "sea-dsa repo")
   add_custom_target(sea-dsa-git
-    ${GIT_EXECUTABLE} clone -b dev14 ${SEA_DSA_REPO} ${SEADSA_SOURCE_DIR})
+    ${GIT_EXECUTABLE} clone -b dev15 ${SEA_DSA_REPO} ${SEADSA_SOURCE_DIR})
 endif()

--- a/lib/Clam/CfgBuilder.cc
+++ b/lib/Clam/CfgBuilder.cc
@@ -2451,7 +2451,8 @@ void CrabIntraBlockBuilder::doAllocFn(CallInst &I) {
 	// ptr  := calloc(num, size) allocates num*size bytes
 	// TODO(TRANSLATION): we ignore that the new allocated memory is zeroed
 	addMakeRefFromCalloc(retRef, rgn, *(I.getOperand(0)), *(I.getOperand(1)));
-      } else if (isReallocLikeFn(&I, m_tli)) {
+      } else if (I.getCalledFunction() &&
+		 isReallocLikeFn(I.getCalledFunction(), m_tli)) {
 	// ptr' := realloc(ptr, new_size)
 	// TODO(TRANSLATION): we ignore that the contents of the new allocated memory
 	addMakeRefFromMalloc(retRef, rgn, *(I.getOperand(1)));
@@ -3342,7 +3343,9 @@ void CrabIntraBlockBuilder::visitCallInst(CallInst &I) {
     return;
   }
 
-  if (isFreeCall(&I, m_tli)) {
+  // LLVM 15: isFreeCall was removed; getFreedOperand returns the freed
+  // pointer operand (non-null) iff the call frees memory.
+  if (getFreedOperand(&I, m_tli)) {
     doFreeFn(I);
     return;
   }

--- a/lib/Transforms/CMakeLists.txt
+++ b/lib/Transforms/CMakeLists.txt
@@ -7,7 +7,7 @@ add_llvm_library(LlvmPasses ${CLAM_LIBS_TYPE} DISABLE_LLVM_LINK_LLVM_DYLIB
   MarkInternalInline.cc
   DevirtFunctions.cc
   DevirtFunctionsPass.cc
-  ExternalizeFunctions.cc  
+  ExternalizeFunctions.cc
   ExternalizeAddressTakenFunctions.cc
   PromoteAssume.cc  
   PromoteMalloc.cc

--- a/lib/Transforms/LoopPeeler.cc
+++ b/lib/Transforms/LoopPeeler.cc
@@ -3,6 +3,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/LoopInfo.h"
 #include "llvm/Analysis/LoopPass.h"
 #include "llvm/Analysis/ScalarEvolution.h"
 #include "llvm/IR/Dominators.h"

--- a/py/clam.py
+++ b/py/clam.py
@@ -43,7 +43,7 @@ CRAB_MEMORY_OUT = 27
 CRAB_SEGFAULT = 28 ## unexpected segfaults
 #############################################################
 
-llvm_version = "14.0"
+llvm_version = "15.0"
 
 def isexec(fpath):
     if fpath is None:

--- a/tools/clam-pp/CMakeLists.txt
+++ b/tools/clam-pp/CMakeLists.txt
@@ -8,8 +8,8 @@ set(LLVM_LINK_COMPONENTS
   scalaropts 
   instrumentation
   transformutils
-  core 
-  codegen 
+  core
+  codegen
   objcarcopts)
 
 add_llvm_executable(clam-pp DISABLE_LLVM_LINK_LLVM_DYLIB clam-pp.cc)

--- a/tools/clam-pp/clam-pp.cc
+++ b/tools/clam-pp/clam-pp.cc
@@ -240,7 +240,10 @@ int main(int argc, char **argv) {
   pass_manager.add(llvm::createInternalizePass(PreserveMain));
 
   if (Devirtualize) {
-    pass_manager.add(llvm::createWholeProgramDevirtPass(nullptr, nullptr));    
+    // LLVM 15 removed the legacy-PM WholeProgramDevirt pass
+    // (createWholeProgramDevirtPass); only the new-PM WholeProgramDevirtPass
+    // remains, which cannot be added to a legacy PassManager. Clam's own
+    // devirtualization pass below performs the indirect-call resolution.
     pass_manager.add(clam::createDevirtualizeFunctionsPass());
   }
 


### PR DESCRIPTION
- CMake: find_package(LLVM 15); pull in zstd imported target first (Ubuntu LLVM 15 exports zstd::libzstd_shared); bump Clam_VERSION_MAJOR to 15; clone sea-dsa/llvm-seahorn from their dev15 branches
- CfgBuilder: adapt to LLVM 15 MemoryBuiltins API — isReallocLikeFn now takes a const Function*; getFreedOperand replaces the removed isFreeCall
- LoopPeeler: include llvm/Analysis/LoopInfo.h explicitly (LLVM 15 dropped the transitive include from LoopPass.h)
- clam-pp: drop the legacy WholeProgramDevirt pass removed in LLVM 15; clam's own createDevirtualizeFunctionsPass still performs indirect-call resolution
- py/clam.py: llvm_version -> 15.0

Known limitations
1.  (issue #103): at -O0, malloc/calloc/realloc/free are not recognized because clang-15 omits the allockind attribute that LLVM 15's allocation/free detection now relies on.

2. https://github.com/seahorn/clam/issues/104

Claude-Session: https://claude.ai/code/session_014SSMemgtucwHsV7Cd7iNMB